### PR TITLE
allow dynamic client_ids

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -43,13 +43,18 @@ module OmniAuth
       private
 
       def id_info
-        id_token = request.params['id_token'] || access_token.params['id_token']
-        log(:info, "id_token: #{id_token}")
-        @id_info ||= ::JWT.decode(id_token, nil, false)[0] # payload after decoding
+        if request.params&.key?('id_token') || access_token&.params&.key?('id_token')
+          id_token = request.params['id_token'] || access_token.params['id_token']
+          log(:info, "id_token: #{id_token}")
+          @id_info ||= ::JWT.decode(id_token, nil, false)[0] # payload after decoding
+        end
       end
 
       def client_id
-        return id_info['aud'] if options.authorized_client_ids.include? id_info['aud']
+        unless id_info.nil?
+          return id_info['aud'] if options.authorized_client_ids.include? id_info['aud']
+        end
+
         options.client_id
       end
 


### PR DESCRIPTION
When using Sign In with Apple with the native iOS flow (outside of the browser), the client_id needs to be set to the app bundle id. I want to support both web login and native login, so I need to dynamically change the client_id. 

This PR adds the possibility to support a dynamic client_id. 

Here's the list of changes:

* Added a config option to set the list of authorized client_ids
* Created a function "client_id" that reads the identityToken which contains the client_id used by the native view. If no identityToken is present, uses the default client_id

This is the implementation omniauth-google-oauth2 used (https://github.com/zquestz/omniauth-google-oauth2/commit/1cd603bb29499f56379aefcd6b34663ef105e165#diff-d61fbf1f9b01eceb09b00d9f200680ca)
 

