### PR TITLE
fix nonce validation

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -76,13 +76,13 @@ module OmniAuth
       def fetch_jwks
         uri = URI.parse('https://appleid.apple.com/auth/keys')
         response = Net::HTTP.get_response(uri)
-        { keys: JSON.parse(response.body)['keys'].map { |key| deep_symbolize(key) } }
+        JSON.parse(response.body, symbolize_names: true)
       end
 
       def verify_nonce!(payload)
-        return unless payload[:nonce_supported]
+        return unless payload['nonce_supported']
 
-        return if payload[:nonce].present? && payload[:nonce] != stored_nonce
+        return if payload['nonce'] && payload['nonce'] == stored_nonce
 
         fail!(:nonce_mismatch, CallbackError.new(:nonce_mismatch, 'nonce mismatch'))
       end


### PR DESCRIPTION
The `payload` argument passed to #verify_nonce! comes directly from JWT.decode which responds with a hash using string keys and not symbols.  Other uses of `id_info` all correctly use string keys.

Without this change, the #verify_nonce! method always handles the payload as if 'nonce_supported' is falsy.