### PR TITLE
add default value of scope as 'email name'

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -13,7 +13,8 @@ module OmniAuth
              authorize_url: '/auth/authorize',
              token_url: '/auth/token'
       option :authorize_params,
-             response_mode: 'form_post'
+             response_mode: 'form_post',
+             scope: 'email name'
       option :authorized_client_ids, []
 
       uid { id_info['sub'] }


### PR DESCRIPTION
Make default scope what I believe is the most common and expected value of 'email name'. User can still over ride as desired of course.
