### PR TITLE
Fix module omniauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- [#31](https://github.com/nhosoya/omniauth-apple/pull/31) Stop relying on ActiveSupport
+- [#31](https://github.com/nhosoya/omniauth-apple/pull/31), [#35](https://github.com/nhosoya/omniauth-apple/pull/35) Avoid using the Rails extensions
 
 ### Changed
 

--- a/lib/omniauth/apple/version.rb
+++ b/lib/omniauth/apple/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Apple
     VERSION = "0.0.3"
   end

--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -82,7 +82,7 @@ module OmniAuth
       def verify_nonce!(payload)
         return unless payload[:nonce_supported]
 
-        return if payload[:nonce].present? && payload[:nonce] != stored_nonce
+        return if payload[:nonce] && payload[:nonce] != stored_nonce
 
         fail!(:nonce_mismatch, CallbackError.new(:nonce_mismatch, 'nonce mismatch'))
       end
@@ -96,10 +96,10 @@ module OmniAuth
       end
 
       def user_info
-        return {} unless request.params['user'].present?
+        user = request.params['user']
+        return {} if user.nil? || user.empty?
 
-        log(:info, "user_info: #{request.params['user']}")
-        @user_info ||= JSON.parse(request.params['user'])
+        @user_info ||= JSON.parse(user)
       end
 
       def email

--- a/omniauth-apple.gemspec
+++ b/omniauth-apple.gemspec
@@ -5,7 +5,7 @@ require "omniauth/apple/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-apple"
-  spec.version       = Omniauth::Apple::VERSION
+  spec.version       = OmniAuth::Apple::VERSION
   spec.authors       = ["nhosoya", "Fabian Jäger"]
   spec.email         = ["hnhnnhnh@gmail.com", "fabian@mailbutler.io"]
 

--- a/spec/omniauth/apple/vesion_spec.rb
+++ b/spec/omniauth/apple/vesion_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../lib/omniauth/apple/version'
+
+describe OmniAuth::Apple do
+  it 'has VERSION' do
+    expect(OmniAuth::Apple::VERSION).to be_a String
+  end
+
+  it 'is correct' do
+    expect(Gem::Version.correct?(OmniAuth::Apple::VERSION)).to be true
+  end
+end


### PR DESCRIPTION
The standard module name is OmniAuth but the name used for the VERSION (and thus in the  gemspec) is Omniauth.

This PR fixes the root module name to be OmniAuth and includes spec tests that verify that.
