### PR TITLE
fix naming of Omniauth module to OmniAuth

### DIFF
--- a/lib/omniauth/apple/version.rb
+++ b/lib/omniauth/apple/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Apple
     VERSION = "0.0.3"
   end

--- a/omniauth-apple.gemspec
+++ b/omniauth-apple.gemspec
@@ -5,7 +5,7 @@ require "omniauth/apple/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-apple"
-  spec.version       = Omniauth::Apple::VERSION
+  spec.version       = OmniAuth::Apple::VERSION
   spec.authors       = ["nhosoya", "Fabian Jäger"]
   spec.email         = ["hnhnnhnh@gmail.com", "fabian@mailbutler.io"]
 

--- a/spec/omniauth/apple/vesion_spec.rb
+++ b/spec/omniauth/apple/vesion_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../lib/omniauth/apple/version'
+
+describe OmniAuth::Apple do
+  it 'has VERSION' do
+    expect(OmniAuth::Apple::VERSION).to be_a String
+  end
+
+  it 'is correct' do
+    expect(Gem::Version.correct?(OmniAuth::Apple::VERSION)).to be true
+  end
+end


### PR DESCRIPTION
The module name for OmniAuth seems to be typo for Omniauth::Apple::VERSION as the `a` should be upper case.

This fixes that issue and adds spec test for version.
