### PR TITLE
Support custom state param

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -39,7 +39,14 @@ module OmniAuth
       end
 
       def authorize_params
-        super.merge(nonce: new_nonce)
+        super.tap do |params|
+          options[:authorize_options].each do |k|
+            params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
+          end
+
+          params[:nonce] = new_nonce
+          session['omniauth.state'] = params[:state] if params[:state]
+        end
       end
 
       def callback_url

--- a/spec/omniauth/strategies/apple_spec.rb
+++ b/spec/omniauth/strategies/apple_spec.rb
@@ -314,4 +314,18 @@ describe OmniAuth::Strategies::Apple do
 
  end
 
+  it 'should set the state parameter' do
+    options.merge!({ state: 'some_state' })
+    expect(subject.authorize_params['state']).to eq('some_state')
+    expect(subject.authorize_params[:state]).to eq('some_state')
+    expect(subject.session['omniauth.state']).to eq('some_state')
+  end
+
+  it 'should set the omniauth.state dynamically' do
+    allow(subject).to receive(:request) { double('Request', params: { 'state' => 'some_state' }, env: {}) }
+    expect(subject.authorize_params['state']).to eq('some_state')
+    expect(subject.authorize_params[:state]).to eq('some_state')
+    expect(subject.session['omniauth.state']).to eq('some_state')
+  end
+
 end


### PR DESCRIPTION
If a state param is given, respect it. This is something useful, and it's also done in [zquestz/omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2)