### PR TITLE
set blank useragent when fetching keys

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -75,8 +75,13 @@ module OmniAuth
       end
 
       def fetch_jwks
+        #Apple returns 403 from some regions if the useragent is set to the default of 'Ruby'
         uri = URI.parse('https://appleid.apple.com/auth/keys')
-        response = Net::HTTP.get_response(uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        request = Net::HTTP::Get.new(uri.request_uri)
+        request['user-agent'] = ""
+        response = http.request(request)
         JSON.parse(response.body, symbolize_names: true)
       end
 


### PR DESCRIPTION
as discussed in issue #70 , fetching keys from a NewYork digital ocean droplet fails with 403 if the user agent is 'Ruby'. @btalbot mentioned that he has seen reports like this elsewhere.

Blank useragent seems to be ok everywhere.