### PR TITLE
Remove script_name from callback_url

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -43,7 +43,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       private


### PR DESCRIPTION
We recently upgraded rails and omniauth, and I'm not sure which one broke things, but all of a sudden this gem started to generate the wrong callback_url, and it adds the `script_name` multiple times now.

Looking at the base strategy, as well as some other popular strategies (github, google) I noticed that they do not include the `script_name` in their `callback_url` method.
[Base](https://github.com/omniauth/omniauth/blob/481e30734762dbd7ac0d54593b0bc34982cb2ae1/lib/omniauth/strategy.rb#L495)
[GitHub](https://github.com/omniauth/omniauth-github/blob/1f772263c6cc00e84dabbc02beb755ba4c95f7d1/lib/omniauth/strategies/github.rb#L78)
[Google](https://github.com/zquestz/omniauth-google-oauth2/blob/e81dcb5dd962590b83d1f5cf7fb53f4e2e6e5b19/lib/omniauth/strategies/google_oauth2.rb#L105)