### PR TITLE
Use ruby/setup-ruby instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake on Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
This commit updates rspec workflow configuration to use `ruby/setup-ruby` GitHub Actions as mentioned by the deprecation message when you try to start a build:

    ------------------------
    NOTE: This action is deprecated and is no longer maintained.
    Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
    ------------------------