### PR TITLE
Allow for omniauth 2.0 series

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -43,7 +43,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       private

--- a/omniauth-apple.gemspec
+++ b/omniauth-apple.gemspec
@@ -36,11 +36,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth-oauth2'
-  spec.add_dependency 'jwt'
+  spec.add_dependency "omniauth-oauth2", "~> 1.7.1"
+  spec.add_dependency "jwt"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "webmock", "~> 3.8"
-  spec.add_development_dependency 'simplecov', "~> 0.18"
+  spec.add_development_dependency "simplecov", "~> 0.18"
 end

--- a/omniauth-apple.gemspec
+++ b/omniauth-apple.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth-oauth2", "~> 1.7.1"
+  spec.add_dependency "omniauth-oauth2", "~> 1.7"
   spec.add_dependency "jwt"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/spec/omniauth/strategies/apple_spec.rb
+++ b/spec/omniauth/strategies/apple_spec.rb
@@ -189,6 +189,22 @@ describe OmniAuth::Strategies::Apple do
     end
   end
 
+  describe '#callback_url' do
+    let(:base_url) { 'https://example.com' }
+
+    it 'has the correct default callback path' do
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '' }
+      expect(subject.send(:callback_url)).to eq(base_url + '/auth/apple/callback')
+    end
+  
+    it 'should set the callback path with script_name if present' do
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '/v1' }
+      expect(subject.send(:callback_url)).to eq(base_url + '/v1/auth/apple/callback')
+    end
+  end
+
   describe '#callback_path' do
     it 'has the correct default callback path' do
       expect(subject.callback_path).to eq('/auth/apple/callback')


### PR DESCRIPTION
Updates to make the gem compatible with omniauth 2.0. The new versions have somewhat of a breaking change on the `script_name` method so gems using the 2.x versions need to account for this change e.g. [omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2/commit/8188e3cec4cda2826ff4e5cbb115ded40809242b)