### PR TITLE
Fix omniauth-apple compatibility with OAuth2 ... maybe

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -61,6 +61,21 @@ module OmniAuth
         options[:redirect_uri] || (full_host + callback_path)
       end
 
+      def callback_phase
+        if request.request_method.downcase.to_sym == :post
+          url = "#{callback_url}"
+
+          if (code = request.params['code']) && (state = request.params['state'])
+            url += "?code=#{CGI::escape(code)}"
+            url += "&state=#{CGI::escape(state)}"
+            url += "&user=#{CGI::escape(request.params['user'])}" if request.params['user']
+          end
+          session.options[:drop] = true # Do not set a session cookie on this response
+          return redirect url
+        end
+        super
+      end
+
       private
 
       def new_nonce


### PR DESCRIPTION
Addresses the issues from https://github.com/nhosoya/omniauth-apple/issues/64, which I barely understand. I took the callback phase from https://github.com/discourse/discourse-apple-auth/blob/40ef076fa744d562ce54f3f30921a1b387e042fb/lib/omniauth_apple.rb#L60-L72, dropped it into a branch, and it worked without issue.

I can't speak for the security of this though, could somebody else smarter than myself chime in about it?