### PR TITLE
remove nonce comparison because `session['omniauth.nonce']` is nil

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -69,10 +69,6 @@ module OmniAuth
         session['omniauth.nonce'] = SecureRandom.urlsafe_base64(16)
       end
 
-      def stored_nonce
-        session.delete('omniauth.nonce')
-      end
-
       def id_info
         @id_info ||= if request.params&.key?('id_token') || access_token&.params&.key?('id_token')
                        id_token_str = request.params['id_token'] || access_token.params['id_token']
@@ -105,7 +101,6 @@ module OmniAuth
         verify_aud!(id_token)
         verify_iat!(id_token)
         verify_exp!(id_token)
-        verify_nonce!(id_token) if id_token[:nonce_supported]
       end
 
       def verify_iss!(id_token)
@@ -122,10 +117,6 @@ module OmniAuth
 
       def verify_exp!(id_token)
         invalid_claim! :exp unless id_token[:exp] >= Time.now.to_i
-      end
-
-      def verify_nonce!(id_token)
-        invalid_claim! :nonce unless id_token[:nonce] && id_token[:nonce] == stored_nonce
       end
 
       def invalid_claim!(claim)

--- a/spec/omniauth/strategies/apple_spec.rb
+++ b/spec/omniauth/strategies/apple_spec.rb
@@ -270,26 +270,6 @@ describe OmniAuth::Strategies::Apple do
       expect(subject.info[:name]).to eq 'first last'
     end
 
-    context 'fails nonce' do
-      context 'when differs from session' do
-        before { subject.session['omniauth.nonce'] = 'abc' }
-        it do
-          expect { subject.info }.to raise_error(
-            OmniAuth::Strategies::OAuth2::CallbackError, 'id_token_claims_invalid | nonce invalid'
-          )
-        end
-      end
-
-      context 'when missing from session' do
-        before { subject.session.delete('omniauth.nonce') }
-        it do
-          expect { subject.info }.to raise_error(
-            OmniAuth::Strategies::OAuth2::CallbackError, 'id_token_claims_invalid | nonce invalid'
-          )
-        end
-      end
-    end
-
     context 'with a spoofed email in the user payload' do
       before do
         request.params['user'] = {
@@ -383,13 +363,6 @@ describe OmniAuth::Strategies::Apple do
               { exp: Time.now - 30 }
             end
             it_behaves_like :invalid_at, :exp
-          end
-
-          context 'on nonce' do
-            let(:invalid_claims) do
-              { nonce: 'invalid' }
-            end
-            it_behaves_like :invalid_at, :nonce
           end
         end
       end


### PR DESCRIPTION
I removed nonce comparison.
I failed authentification with omniauth-apple 1.3.0, and I found that `session['omniauth.nonce']` is nil.
`session['omniauth.nonce']` is assigned after called `authorize_params`, but  `authorize_params` is never called.
In addition, `session['omniauth.nonce']` is generated in application, and id_token[:nonce] is generated server in Apple.

ref #102  
ref #103