### PR TITLE
fix(hybrid): allow sending redirect_uri param to avoid redirect URI mismatch errors

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -2,6 +2,7 @@
 
 require 'omniauth-oauth2'
 require 'json/jwt'
+require 'pry'
 
 module OmniAuth
   module Strategies
@@ -60,7 +61,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:redirect_uri] || (full_host + callback_path)
+        request.params['redirect_uri'] || options[:redirect_uri] || (full_host + callback_path)
       end
 
       private

--- a/omniauth-apple.gemspec
+++ b/omniauth-apple.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth-oauth2'
   spec.add_dependency 'json-jwt'
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "pry", "~> 0.15.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "webmock", "~> 3.8"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,5 @@ OmniAuth.config.logger = Logger.new(nil)
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!
+
+require 'pry'


### PR DESCRIPTION
closes #115 

## Summary
When using `omniauth-apple` with a API only Rails application it's common for the initial request to be made from the client side application instead of from Rails.
The client side application then receives a authorization code which it POST to `/auth/apple/callback` and the code is verified from the API before finally signing the user in.

When doing so the `redirect_uri` used in the callback process needs to be the same as the `redirect_uri` used in the request process so we need to be able to share that `redirect_uri` from the client side app to the API.

This is also the case with other `omniauth-<provider>` gem.

This PR allows sending a `redirect_uri` param to the `/auth/apple/callback` endpoint from a client side application and ensures that param will be used when present to avoid redirect uri mismatch errors.

---

Until this PR is merged this issue can be monkey patched by initializing a custom class that will override this gem
```ruby
# config/initializers/omniauth-apple-monkey-patch.rb
module OmniAuth
  module Strategies
    class Apple
      def callback_url
        request.params['redirect_uri'] || options[:redirect_uri] || (full_host + callback_path)
      end
    end
  end
end
```