### PR TITLE
fix(client_id): include options.client_id in authorized id_info[:aud]

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -65,6 +65,10 @@ module OmniAuth
 
       private
 
+      def authorized_client_ids
+        [options.client_id].concat(options.authorized_client_ids)
+      end
+
       def new_nonce
         session['omniauth.nonce'] = SecureRandom.urlsafe_base64(16)
       end
@@ -113,7 +117,7 @@ module OmniAuth
       end
 
       def verify_aud!(id_token)
-        invalid_claim! :aud unless [options.client_id].concat(options.authorized_client_ids).include?(id_token[:aud])
+        invalid_claim! :aud unless authorized_client_ids.include?(id_token[:aud])
       end
 
       def verify_iat!(id_token)
@@ -135,8 +139,8 @@ module OmniAuth
       def client_id
         @client_id ||= if id_info.nil?
                          options.client_id
-                       else
-                         id_info[:aud] if options.authorized_client_ids.include? id_info[:aud]
+                       elsif authorized_client_ids.include?(id_info[:aud])
+                         id_info[:aud]
                        end
       end
 


### PR DESCRIPTION
## Summary
In the callback phase, when a `id_token` is present (which can be the case when signing in from a client-side application for example) the `client_id` used to verify the authorization `code` is extracted from the `id_token[:aud]`.

The extracted `:aud` is then compared to the `authorized_client_ids` option and used if present in that list.

This means that if no `authorized_client_ids` were provided in the middleware's configuration, despite there being a `CLIENT_ID`, the callback will fail with a `invalid_client_id` error.

A solution is to duplicate the client_id this way
```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :apple, ENV['CLIENT_ID'], '',
           {
             authorized_client_ids: [ENV['CLIENT_ID']], # Add this
             scope: 'email name',
             team_id: ENV['TEAM_ID'],
             key_id: ENV['KEY_ID'],
             pem: ENV['PRIVATE_KEY']
           }
end
```

But I find this to be highly non-intuitive.

Instead I include the `options.client_id` when validating the `:aud` which solves the issue